### PR TITLE
Avoid prompting if the app is already under an Applications folder

### DIFF
--- a/PFMoveApplication.m
+++ b/PFMoveApplication.m
@@ -279,6 +279,7 @@ static NSString *PreferredInstallLocation(BOOL *isUserDirectory)
 
 static BOOL IsInApplicationsFolder(NSString *path)
 {
+	// Check all the normal Application directories
 	NSEnumerator *e = [NSSearchPathForDirectoriesInDomains(NSApplicationDirectory, NSAllDomainsMask, YES) objectEnumerator];
 	NSString *appDirPath = nil;
 
@@ -286,6 +287,10 @@ static BOOL IsInApplicationsFolder(NSString *path)
 		if ([path hasPrefix:appDirPath]) return YES;
 	}
 
+	// Also, handle the case that the user has some other Application directory (perhaps on a separate data partition).
+	if ([[path pathComponents] containsObject:@"Applications"])
+            return YES;
+        
 	return NO;
 }
 


### PR DESCRIPTION
I put my 3rd party apps in /Volumes/Space/Applications so they can be shared among multiple boot partitions (Mac OS X betas, beta dev tools, etc). This confuses many of the nice apps that have integrated the 'move to Applications' checking, so I've written up a patch to handle this case.

Thanks!
