### PR TITLE
Improved compatibility for 10.7 builds.

### DIFF
--- a/PFMoveApplication.m
+++ b/PFMoveApplication.m
@@ -18,6 +18,7 @@
 #import "PFMoveApplication.h"
 #import "NSString+SymlinksAndAliases.h"
 #import <Security/Security.h>
+#import <dlfcn.h>
 
 // Strings
 // These are macros to be able to use custom i18n tools
@@ -373,10 +374,25 @@ static BOOL AuthorizedInstall(NSString *srcPath, NSString *dstPath, BOOL *cancel
 		goto fail;
 	}
 
+	static OSStatus (*security_AuthorizationExecuteWithPrivileges)(AuthorizationRef authorization, const char *pathToTool,
+																   AuthorizationFlags options, char * const *arguments,
+																   FILE **communicationsPipe) = NULL;
+	if (!security_AuthorizationExecuteWithPrivileges) {
+		// On 10.7, AuthorizationExecuteWithPrivileges is deprecated. We want to still use it since there's no
+		// good alternative (without requiring code signing). We'll look up the function through dyld and fail
+		// if it is no longer accessible. If Apple removes the function entirely this will fail gracefully. If
+		// they keep the function and throw some sort of exception, this won't fail gracefully, but that's a
+		// risk we'll have to take for now.
+		security_AuthorizationExecuteWithPrivileges = dlsym(RTLD_DEFAULT, "AuthorizationExecuteWithPrivileges");
+	}
+	if (!security_AuthorizationExecuteWithPrivileges) {
+		goto fail;
+	}
+
 	// Delete the destination
 	{
 		char *args[] = {"-rf", (char *)[dstPath fileSystemRepresentation], NULL};
-		err = AuthorizationExecuteWithPrivileges(myAuthorizationRef, "/bin/rm", kAuthorizationFlagDefaults, args, NULL);
+		err = security_AuthorizationExecuteWithPrivileges(myAuthorizationRef, "/bin/rm", kAuthorizationFlagDefaults, args, NULL);
 		if (err != errAuthorizationSuccess) goto fail;
 
 		// Wait until it's done
@@ -387,7 +403,7 @@ static BOOL AuthorizedInstall(NSString *srcPath, NSString *dstPath, BOOL *cancel
 	// Copy
 	{
 		char *args[] = {"-pR", (char *)[srcPath fileSystemRepresentation], (char *)[dstPath fileSystemRepresentation], NULL};
-		err = AuthorizationExecuteWithPrivileges(myAuthorizationRef, "/bin/cp", kAuthorizationFlagDefaults, args, NULL);
+		err = security_AuthorizationExecuteWithPrivileges(myAuthorizationRef, "/bin/cp", kAuthorizationFlagDefaults, args, NULL);
 		if (err != errAuthorizationSuccess) goto fail;
 
 		// Wait until it's done


### PR DESCRIPTION
No longer assuming that AuthorizationExecuteWithPrivileges will be defined and looking it up via dyld.

This gets rid of a few warnings that are generated when using the code and targeting 10.7+.
