### PR TITLE
Only move to user Applications folder if already in use.

### DIFF
--- a/PFMoveApplication.m
+++ b/PFMoveApplication.m
@@ -285,13 +285,27 @@ static NSString *PreferredInstallLocation(BOOL *isUserDirectory) {
 		NSString *userApplicationsDir = [userApplicationsDirs objectAtIndex:0];
 		BOOL isDirectory;
 
-		if ([fm fileExistsAtPath:userApplicationsDir isDirectory:&isDirectory] && isDirectory) {
-			if (isUserDirectory) *isUserDirectory = YES;
-			return [userApplicationsDir stringByResolvingSymlinksAndAliases];
+        if ([fm fileExistsAtPath:userApplicationsDir isDirectory:&isDirectory] && isDirectory) {            
+            // User Applications directory exists. Get the directory contents.
+            NSError *error=nil;
+            NSArray *contents=[fm contentsOfDirectoryAtPath:userApplicationsDir error:&error];
+            
+            // Check if there is at least one ".app" inside the directory.
+            BOOL containsApp=NO;
+            for (NSString *contentsPath in contents) {
+                if ([[contentsPath pathExtension] isEqualToString:@"app"]) {
+                    containsApp=YES;
+                    break;
+                }
+            }
+            if (containsApp) {
+                if (isUserDirectory) *isUserDirectory = YES;
+                return [userApplicationsDir stringByResolvingSymlinksAndAliases];
+            }
 		}
 	}
 
-	// No user Applications directory. Return the machine local Applications directory
+	// No user Applications directory in use. Return the machine local Applications directory
 	if (isUserDirectory) *isUserDirectory = NO;
 	return [[NSSearchPathForDirectoriesInDomains(NSApplicationDirectory, NSLocalDomainMask, YES) lastObject] stringByResolvingSymlinksAndAliases];
 }


### PR DESCRIPTION
With this change, PreferredInstallLocation() only returns `~/Applications` over `/Applications` if it exists AND contains other apps already.

The extra check is to see if the user is actually using `~/Applications` to store applications, and thus avoid surprising the user if they are not.

Rationale: I have used PFMoveApplication in a shipping app and several customers contacted me to ask why the app installed itself in their (empty) `~/Applications` directory. It turned out they had this directory on disk but were not using it. (I don't know how it gets created. I guess some third party app or install script does it.)
