### PR TITLE
Exception caused by substringToIndex:

### DIFF
--- a/PFMoveApplication.m
+++ b/PFMoveApplication.m
@@ -160,7 +160,7 @@ void PFMoveToApplicationsFolderIfNecessary() {
 				else {
 					for (NSRunningApplication *runningApplication in [[NSWorkspace sharedWorkspace] runningApplications]) {
 						NSString *executablePath = [[runningApplication executableURL] path];
-						if ([[executablePath substringToIndex:[destinationPath length]] isEqualToString:destinationPath]) {
+						if ([executablePath hasPrefix:destinationPath]) {
 							destinationIsRunning = YES;
 							break;
 						}


### PR DESCRIPTION
This fixes an exception that will almost certainly occur if there's something already running at or inside destinationPath. substringToIndex: was missing a range check. I substituted this for hasPrefix: instead.
