### PR TITLE
Allow specifying the app bundle name

### DIFF
--- a/LetsMove-Info.plist
+++ b/LetsMove-Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>PFDesiredAppBundleName</key>
+	<string>MyCoolApp.app</string>
 </dict>
 </plist>

--- a/PFMoveApplication.m
+++ b/PFMoveApplication.m
@@ -39,6 +39,7 @@
 
 
 static NSString *AlertSuppressKey = @"moveToApplicationsFolderAlertSuppress";
+static NSString *DesiredAppBundleNameKey = @"PFDesiredAppBundleName";
 
 
 // Helper functions
@@ -70,7 +71,13 @@ void PFMoveToApplicationsFolderIfNecessary() {
 	// Since we are good to go, get the preferred installation directory.
 	BOOL installToUserApplications = NO;
 	NSString *applicationsDirectory = PreferredInstallLocation(&installToUserApplications);
-	NSString *bundleName = [bundlePath lastPathComponent];
+    
+    // Attemp to get the desired application bundle name from the info plist
+    NSString *bundleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:DesiredAppBundleNameKey];
+    if (!bundleName) {
+        // No bundle name in the Info.plist so fall back to getting the last component of the bundle's path
+        bundleName = [bundlePath lastPathComponent];
+    }
 	NSString *destinationPath = [applicationsDirectory stringByAppendingPathComponent:bundleName];
 
 	// Check if we need admin password to write to the Applications directory


### PR DESCRIPTION
Our users started running into a problem where they would download the app several times and instead of running OurApp.app they'd run "OurApp 3.app" or something like that. In this situation we want the app to be moved to /Applications and renamed to OurApp.app. To this end we tweaked PFMoveToApplicationsFolderIfNecessary to allow specifying the desired app bundle name by setting a value for the PFDesiredAppBundleName key in Info.plist
