### PR TITLE
fix a compile error

### DIFF
--- a/PFMoveApplication.h
+++ b/PFMoveApplication.h
@@ -8,4 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-void PFMoveToApplicationsFolderIfNecessary(void);
+#ifdef __cplusplus
+extern "C" {
+    void PFMoveToApplicationsFolderIfNecessary(void);
+}
+#endif


### PR DESCRIPTION
When I must change my `AppDelegate.m` to a `AppDelegate.mm` file for some reason, I will get the following error:

![3dd886cf-6d3e-487c-a2ef-0231aa80475c](https://cloud.githubusercontent.com/assets/2641747/2993237/f93dc644-dcab-11e3-89b6-e2ecb090e3a9.png)

Is it better always compile it as c method?
