### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/PFMoveApplication.m
+++ b/PFMoveApplication.m
@@ -309,7 +309,9 @@ static NSString *ContainingDiskImageDevice(void) {
 	}
 	else {
 #endif
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_10
 		info = [NSPropertyListSerialization propertyListFromData:data mutabilityOption:NSPropertyListImmutable format:NULL errorDescription:NULL];
+#endif
 #if MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_5
 	}
 #endif


### PR DESCRIPTION
Fixed warnings when building with a minimum deployment target set to OS X 10.10.
