### PR TITLE
added a CocoaPods podspec

### DIFF
--- a/LetsMove.podspec
+++ b/LetsMove.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name         = "LetsMove"
+  s.version      = "1.16"
+  s.summary      = "Moves a running Mac application to the /Applications directory."
+  s.homepage     = "https://github.com/potionfactory/LetsMove/"
+  s.license      = 'Public Domain'
+  s.author       = { "Andy Kim" => "andy@potionfactory.com" }
+
+  s.platform     = :osx, '10.6'
+
+  s.source = {
+    :git => "https://github.com/potionfactory/LetsMove.git",
+    :tag => "v1.16"
+  }
+
+  s.source_files = '*.{h,m}'
+  s.exclude_files = 'main.m', 'LetsMoveAppDelegate.{h,m}'
+  s.public_header_files = 'PFMoveApplication.h'
+
+  s.resources = '*.lproj'
+  s.requires_arc = false
+end


### PR DESCRIPTION
Hi,

as a continuation of #32...

> Actually I'm not in charge of the CocoaPods. I don't even know who puts it up there or how to do it.

The pod for LetsMove 1.9 that is currently there was added by @nschum while working on hive-osx. I haven't published any pods before, so I had no idea how that works either. I've done some research, and in a nutshell:

- previously (back when that first pod was added) pods were added by publishing `*.podspec` files, which are config files written in Ruby, in the main CocoaPods repo (https://github.com/CocoaPods/Specs), by just sending a pull request with a specific file for a specific version to them. One guy there had to accept every pull request for every new version of every library manually.

- half a year ago they introduced a new setup, where the specs repo is in the same place, but is managed automatically by their server; the new workflow for pushing new versions is to have a single `*.podspec` file in your repo, and when you publish a new version, you update the version line in that file, and run `pod trunk push` which tells the CocoaPods server to add a new version to the repo

I've added the podspec for the latest version here for you (basically copied over from the old version by @nschum). So for 1.17 you'll need to:

- add a `v1.17` tag in git
- update the `s.version` and `:tag` lines in the podspec file
- run `pod trunk push LetsMove.podspec` in the terminal

That's it. I tried to push v. 1.16 there but it doesn't let me, which means it has already assigned an owner, I assume that's you (if not then it's @nschum :), so you'll need to do this too.

The first time you'll also need to "log in" to the trunk service with your email, see http://guides.cocoapods.org/making/getting-setup-with-trunk.html (and install cocoapods, obviously).
