### PR TITLE
Add PFMoveIsInProgress method to work around applicationShouldTerminateAfterLastWindowClosed issue

### DIFF
--- a/PFMoveApplication.h
+++ b/PFMoveApplication.h
@@ -11,7 +11,8 @@ extern "C" {
 #endif
 
 void PFMoveToApplicationsFolderIfNecessary(void);
-
+BOOL PFMoveIsInProgress();
+  
 #ifdef __cplusplus
 }
 #endif

--- a/PFMoveApplication.m
+++ b/PFMoveApplication.m
@@ -215,6 +215,10 @@ fail:
 	}
 }
 
+// Function to check whether an app move is currently in progress
+// Returns YES if LetsMove is currently in-progress trying to move the app to the Applications folder, or NO otherwise
+// This can be used to work around a crash with apps that terminate after last window is closed.
+// See https://github.com/potionfactory/LetsMove/issues/64 for details.
 BOOL PFMoveIsInProgress() {
     return MoveInProgress;
 }


### PR DESCRIPTION
In issue #64 I noted that the AppleScript trashing method was crashing consistently on my machine, and the proximate cause was that my application terminated at last window close due to returning yes to `applicationShouldTerminateAfterLastWindowClosed`.

I tried for a few hours but couldn't fix up the AppleScript, so I did the next best thing: I added a `PFMoveIsInProgress` so we can know when a move is in progress, and make sure the app doesn't terminate then. You can see the SelfControl commit where I uptook this [here](https://github.com/SelfControlApp/selfcontrol/commit/d5dfd34cb63f3d2f4433b44618551762d9d90f10).

Please consider merging when you have a chance, thank you!