### PR TITLE
Dispatch to main thread if not called from main

### DIFF
--- a/PFMoveApplication.m
+++ b/PFMoveApplication.m
@@ -57,6 +57,14 @@ static void Relaunch(NSString *destinationPath);
 
 // Main worker function
 void PFMoveToApplicationsFolderIfNecessary(void) {
+	if (![NSThread isMainThread])
+	{
+		dispatch_async(dispatch_get_main_queue(), ^{
+			PFMoveToApplicationsFolderIfNecessary();
+		});
+		return;
+	}
+	
 	// Skip if user suppressed the alert before
 	if ([[NSUserDefaults standardUserDefaults] boolForKey:AlertSuppressKey]) return;
 


### PR DESCRIPTION
We're using this in an Electon app and can't directly dispatch to main, so this is handy. 

This also makes it a little more foolproof other consumers.