### PR TITLE
Fixed: BOOL requires objc import

### DIFF
--- a/PFMoveApplication.h
+++ b/PFMoveApplication.h
@@ -10,6 +10,8 @@
 extern "C" {
 #endif
 
+#import <objc/objc.h>
+
 /**
  Moves the running application to ~/Applications or /Applications if the former does not exist.
  After the move, it relaunches app from the new location.
@@ -23,7 +25,7 @@ void PFMoveToApplicationsFolderIfNecessary(void);
  Returns YES if LetsMove is currently in-progress trying to move the app to the Applications folder, or NO otherwise.
  This can be used to work around a crash with apps that terminate after last window is closed.
  See https://github.com/potionfactory/LetsMove/issues/64 for details. */
-BOOL PFMoveIsInProgress();
+BOOL PFMoveIsInProgress(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Might be specific to Xcode 9, but the project won’t compile.
> Unknown type name ‘BOOL’

BOOL is declared in objc.h and it’s not imported.

Also fixes this warning:
> This declaration is not a prototype; add ‘void' to make it a prototype for a zero-parameter function